### PR TITLE
Add status check for token fetch

### DIFF
--- a/loadbot.go
+++ b/loadbot.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -152,6 +154,10 @@ func fetchToken(endpoint, room, identity string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("unexpected status %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
 	var j map[string]string
 	if err := json.NewDecoder(resp.Body).Decode(&j); err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- ensure token fetch checks HTTP status code and returns an error if non-200

## Testing
- `go vet ./...` *(fails: no required module)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd23dbfc832694980945a3556fd0