### PR TITLE
Add track event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ See `go run loadbot.go -h` for all available flags.
 
 Passing the `-log` flag (or answering `y` when prompted by the script) will
 write NDJSON formatted logs to `last_run.json`. Each line describes a bot event
-(join, leave, errors, etc.) with a timestamp, making it easier to inspect or
-process later.
+(join, leave, track events, errors, etc.) with a timestamp, making it easier to
+inspect or process later.


### PR DESCRIPTION
## Summary
- log track events with participant and track information
- document that track events are included in `last_run.json`

## Testing
- `go vet ./...` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd2481648326bac48eda7ae604ee