### PR TITLE
Remove stub replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,3 @@ go 1.24.3
 
 require github.com/livekit/server-sdk-go/v2 v2.0.0
 
-replace github.com/livekit/server-sdk-go/v2 => ./stubs/github.com/livekit/server-sdk-go/v2


### PR DESCRIPTION
## Summary
- use the real `github.com/livekit/server-sdk-go/v2` by removing the `replace` directive

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go run loadbot.go` *(fails: missing go.sum)*

------
https://chatgpt.com/codex/tasks/task_e_685bd881a9148326bb407518ed16eb68