### PR TITLE
Add setup script for deps and media

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ stub so the project can compile without internet access.
 To perform live testing with the real SDK, remove the `replace` line from
 `go.mod` and run `go mod download` to fetch the actual dependency.
 
+## Setup script
+
+Before running the load tests you can execute `./setup.sh` to fetch the Go
+dependencies and download the sample media files:
+
+```bash
+./setup.sh
+```
+
 ## Running the load test
 
 The easiest way to run the test is via the interactive helper script:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure Go is installed
+if ! command -v go >/dev/null 2>&1; then
+  echo "Go is required but was not found. Please install Go 1.24.3 from https://go.dev/dl/" >&2
+  exit 1
+fi
+
+echo "Fetching Go dependencies..."
+go mod download
+
+echo "Downloading sample media files..."
+./get-media.sh


### PR DESCRIPTION
## Summary
- add setup.sh script that verifies Go installation, downloads dependencies and media files
- document usage of setup script in README

## Testing
- `bash -n setup.sh`
- `./setup.sh` *(fails: `Forbidden` from proxy)*
- `go build ./...` *(fails: missing go.sum)*

------
https://chatgpt.com/codex/tasks/task_e_685be450e5d4832682ab21ac03de89a9