### PR TITLE
Update docs: remove bundled media

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.ivf filter=lfs diff=lfs merge=lfs -text
-*.ogg filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ go.work.sum
 # .vscode/
 
 last_run.json
+
+# Sample media files
+sample720p.ivf
+sample.ogg

--- a/README.md
+++ b/README.md
@@ -8,14 +8,20 @@ participants against a LiveKit server for basic stress testing.
 
 1. Install **Go 1.24.3** on your machine.
 2. Clone this repository and change into the project directory.
-3. Ensure [Git LFS](https://git-lfs.com/) is installed so the sample media
-   files (`sample720p.ivf` and `sample.ogg`) are downloaded automatically when
-   cloning. If they are missing, you can grab them from the [LiveKit example
-  media folder](https://github.com/livekit/client-sdk-js/tree/main/examples/media)
-  and place them in this directory. These files are published by each bot when
-  it joins a room.
-  The provided `sample720p.ivf` and `sample.ogg` each contain about one minute
-  of test video and audio for simulated camera and microphone input.
+3. Create two sample media files for the bots to publish:
+   `sample720p.ivf` (VP8 video) and `sample.ogg` (Opus audio). These files are
+   **not** stored in the repository.
+
+   Example using [ffmpeg](https://ffmpeg.org/):
+
+   ```bash
+   ffmpeg -i input.mp4 -c:v libvpx -an sample720p.ivf
+   ffmpeg -i input.wav -c:a libopus -ar 48000 -ac 2 sample.ogg
+   ```
+
+   Place the generated files in this directory. Each should be about one minute
+   of media (~1.5 MB for video, ~100 KB for audio). They are published by each
+   bot when it joins a room.
 
 ## Running the load test
 

--- a/run-custom.sh
+++ b/run-custom.sh
@@ -13,6 +13,7 @@ read -p "💾 Save logs to JSON file? (y/n): " SAVE_LOG
 for f in sample720p.ivf sample.ogg; do
   if [[ ! -f $f ]]; then
     echo "Missing media file: $f" >&2
+    echo "Create it using ffmpeg as described in the README." >&2
     exit 1
   fi
 done

--- a/sample.ogg
+++ b/sample.ogg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3de5580652c66d0aad315374cd667cd02bfe3c95a867508300ea28a2b4dcbc9f
-size 122464

--- a/sample720p.ivf
+++ b/sample720p.ivf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0125df2dc0ab20a83fd8c2d86c7fd4b703429ef31d89bc419a6e153b2190d895
-size 1527175


### PR DESCRIPTION
## Summary
- instruct users to generate sample media with ffmpeg instead of relying on Git LFS
- warn in `run-custom.sh` if media files are missing
- remove `sample720p.ivf` and `sample.ogg` from the repo
- ignore sample media files and delete LFS settings

## Testing
- `gofmt -w loadbot.go`
- `shellcheck run-custom.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfffaf75c8326a2155b526ddd4fe5