### PR TITLE
Fix blank video by publishing track with dimensions

### DIFF
--- a/loadbot.go
+++ b/loadbot.go
@@ -112,7 +112,11 @@ func main() {
 				}
 
 				if vt, err := lksdk.NewLocalFileTrack(*videoFile); err == nil {
-					if _, err := roomConn.LocalParticipant.PublishTrack(vt, nil); err != nil {
+					pubOpts := &lksdk.TrackPublicationOptions{
+						VideoWidth:  1280,
+						VideoHeight: 720,
+					}
+					if _, err := roomConn.LocalParticipant.PublishTrack(vt, pubOpts); err != nil {
 						log.Printf("video publish error: %v", err)
 						logEvt("video_error", err)
 					}


### PR DESCRIPTION
## Summary
- publish video with explicit dimensions to avoid blank playback

## Testing
- `go vet ./...`
- `shellcheck run-custom.sh` *(fails: SC2162)*

------
https://chatgpt.com/codex/tasks/task_e_685c0c92cafc83269d8bae35daae55e6